### PR TITLE
Added IP_TYPE option in mbim-network

### DIFF
--- a/utils/mbim-network.in
+++ b/utils/mbim-network.in
@@ -70,7 +70,11 @@ help ()
     echo "   in the profile:"
     echo "      PROXY=yes"
     echo
-    echo "   7) Once the mbim-network script reports a successful connection"
+    echo "   7) If you want to instruct the mbim-network script to use the"
+    echo "   a specific IP type (ivp4|ipv6|ipv4v6)"
+    echo "      IP_TYPE=(ivp4|ipv6|ipv4v6)"
+    echo
+    echo "   8) Once the mbim-network script reports a successful connection"
     echo "   you still need to run a DHCP client on the associated WWAN network"
     echo "   interface."
     echo
@@ -190,6 +194,12 @@ load_profile ()
         else
             echo "    mbim-proxy: no"
         fi
+	
+        if [ -n "$IP_TYPE" ]; then
+            echo "    ip-type: $IP_TYPE"
+        else
+            echo "    ip-type: unset"
+        fi
     else
         echo "Profile at '$PROFILE_FILE' not found..."
     fi
@@ -298,7 +308,13 @@ connect ()
                 CONNECT_ARGS="${CONNECT_ARGS},password='$APN_PASS'"
             fi
         fi
+	
     fi
+
+    if [ -n "$IP_TYPE" ]; then
+        CONNECT_ARGS="${CONNECT_ARGS},ip-type='$IP_TYPE'"
+    fi
+
 
     CONNECT_CMD="mbimcli -d $DEVICE --connect=$CONNECT_ARGS --no-open=$TRID --no-close $PROXY_OPT"
     echo "Starting network with '$CONNECT_CMD'..."


### PR DESCRIPTION
Adds support for an IP_TYPE parameter in mbim-network.conf, which specifies if the APN connection should be ipv4, ipv6 or ipv4v6.

There is no input validation on this parameter, as it assumes that `mbimcli --connect` will handle that 